### PR TITLE
Fix an error when setting the legend position to 'none'

### DIFF
--- a/lib/writeexcel/chart.rb
+++ b/lib/writeexcel/chart.rb
@@ -1107,7 +1107,7 @@ class Chart < Worksheet
 
     # Note, the CHARTFORMATLINK record is only written by Excel.
 
-    if @legend[:visible]
+    if @legend[:visible] != 0
         store_legend_stream
     end
 


### PR DESCRIPTION
When setting the legend position to 'none' the gem crashes because it tries to access the "legend" var instead of the existing "@legend" initialized by the "set_default_properties" method.

Also fix the check on the @legend[:visible] to effectively hide the legend when setting the position to 'none' 
