### PR TITLE
Add block support for Workbook#initialize. This closes #31

### DIFF
--- a/lib/writeexcel/version.rb
+++ b/lib/writeexcel/version.rb
@@ -1,5 +1,5 @@
 require 'writeexcel'
 
 class WriteExcel < Workbook
-  VERSION = "1.0.5"
+  VERSION = "1.0.6"
 end

--- a/lib/writeexcel/workbook.rb
+++ b/lib/writeexcel/workbook.rb
@@ -130,6 +130,13 @@ class Workbook < BIFFWriter
 
     # Set colour palette.
     set_palette_xl97
+
+    return unless block_given?
+    begin
+      yield self
+    ensure
+      close
+    end
   end
 
   #

--- a/test/test_workbook.rb
+++ b/test/test_workbook.rb
@@ -13,6 +13,16 @@ class TC_Workbook < Test::Unit::TestCase
     assert_kind_of(Workbook, @workbook)
   end
 
+  def test_new_with_block
+    test_file = StringIO.new
+    workbook = Workbook.new(test_file) do |book|
+      book.add_worksheet('test_block')
+    end
+
+    assert_kind_of(Workbook, workbook)
+    assert_true(test_file.closed?)
+  end
+
   def test_add_worksheet
     sheetnames = ['sheet1', 'sheet2']
     (0 .. sheetnames.size-1).each do |i|


### PR DESCRIPTION
Add block yield inside `Workbook#initialize`. Usage:

```ruby
WriteExcel.new('ruby.xls') do |book|
  worksheet = book.add_worksheet
  worksheet.write('A1', 'Hi Excel!')
end
```
